### PR TITLE
[CI/Build] use existing shadow-utils in Dockerfile.ubi

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -235,11 +235,8 @@ ENV HF_HUB_OFFLINE=1 \
     VLLM_WORKER_MULTIPROC_METHOD=fork
 
 # setup non-root user for OpenShift
-RUN microdnf install -y shadow-utils \
-    && umask 002 \
+RUN umask 002 \
     && useradd --uid 2000 --gid 0 vllm \
-    && microdnf remove -y shadow-utils \
-    && microdnf clean all \
     && chmod g+rwx $HOME /usr/src /workspace
 
 COPY LICENSE /licenses/vllm.md


### PR DESCRIPTION
Shadow-utils is required by rpm and dnf. It's already in the image.
Just use it and don't remove it or it makes the image bigger.