### PR TITLE
grpc_server: fix tokenizer group usage

### DIFF
--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -107,7 +107,6 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         self.engine: AsyncLLMEngine = engine
 
         # These set in _post_init()
-        self.tokenizer_group: BaseTokenizerGroup = None
         self.tokenizer: Union[PreTrainedTokenizer,
                               PreTrainedTokenizerFast] = None
         self.config: ModelConfig = None
@@ -116,9 +115,13 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         self.skip_special_tokens = not args.output_special_tokens
         self.default_include_stop_seqs = args.default_include_stop_seqs
 
+    @property
+    def tokenizer_group(self) -> BaseTokenizerGroup:
+        return self.engine.engine
+
+
     async def _post_init(self):
         self.config = await self.engine.get_model_config()
-        self.tokenizer_group = await self.engine.get_tokenizer_group()
         self.tokenizer = await self.engine.get_tokenizer()
 
         # Swap in the special TGIS stats logger


### PR DESCRIPTION
Without this fix, the grpc server won't start:

```
ERROR:    Traceback (most recent call last):
  File "/opt/vllm/lib64/python3.11/site-packages/starlette/routing.py", line 732, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/usr/lib64/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 60, in lifespan
    grpc_server = await start_grpc_server(async_llm_engine, args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.11/site-packages/vllm/entrypoints/grpc/grpc_server.py", line 600, in start_grpc_server
    await service._post_init()
  File "/opt/vllm/lib64/python3.11/site-packages/vllm/entrypoints/grpc/grpc_server.py", line 121, in _post_init
    self.tokenizer_group = await self.engine.get_tokenizer_group()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'AsyncLLMEngine' object has no attribute 'get_tokenizer_group'
```

