### PR TITLE
Dockerfile.ubi: remove vllm-nccl workaround

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -183,22 +183,9 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
     --mount=type=cache,target=/root/.cache/pip \
     pip install dist/*.whl --verbose
 
-# vllm requires a specific nccl version built from source distribution
-# See https://github.com/NVIDIA/nccl/issues/1234
-RUN pip install \
-        -v \
-        --force-reinstall \
-        --no-binary="all" \
-        --no-cache-dir \
-        "vllm-nccl-cu12==2.18.1.0.4.0" && \
-    mv /root/.config/vllm/nccl/cu12/libnccl.so.2.18.1 /opt/vllm/lib/ && \
-    chmod 0755 /opt/vllm/lib/libnccl.so.2.18.1
-
-
 ENV HF_HUB_OFFLINE=1 \
     PORT=8000 \
     HOME=/home/vllm \
-    VLLM_NCCL_SO_PATH=/opt/vllm/lib/libnccl.so.2.18.1 \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork
 


### PR DESCRIPTION
Fixed upstream in https://github.com/vllm-project/vllm/pull/5091
