### PR TITLE
gha: sync-with-upstream workflow create PRs as draft

### DIFF
--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -72,6 +72,7 @@ jobs:
               --label code-sync \
               --title "$title" \
               --body "$body" \
+              --draft \
               --no-maintainer-edit
             exit 0
           fi


### PR DESCRIPTION
this avoids triggering CI on each upstream update