### PR TITLE
Dockerfile.ubi: bump vllm-tgis-adapter to 0.1.3

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -189,7 +189,7 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.1.2
+    pip install vllm-tgis-adapter==0.1.3
 
 ENV GRPC_PORT=8033
 USER 2000


### PR DESCRIPTION
fixes [RHOAIENG-9356](https://issues.redhat.com/browse/RHOAIENG-9356)