### PR TITLE
Dockerfile.ubi: get rid of --distributed-executor-backend=mp

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -181,7 +181,7 @@ RUN umask 002 \
 COPY LICENSE /licenses/vllm.md
 
 USER 2000
-ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server", "--distributed-executor-backend=mp"]
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 
 
 FROM vllm-openai as vllm-grpc-adapter
@@ -193,4 +193,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 ENV GRPC_PORT=8033
 USER 2000
-ENTRYPOINT ["python3", "-m", "vllm_tgis_adapter", "--distributed-executor-backend=mp"]
+ENTRYPOINT ["python3", "-m", "vllm_tgis_adapter"]


### PR DESCRIPTION
this is the default when `--worker-use-ray` is not provided and more than 1 GPU is available
