### PR TITLE
deps: bump flashinfer to 0.0.9

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -167,7 +167,7 @@ RUN --mount=type=bind,from=libsodium-builder,src=/usr/src/libsodium,target=/usr/
     && make install
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install https://github.com/flashinfer-ai/flashinfer/releases/download/v0.0.8/flashinfer-0.0.8+cu121torch2.3-cp311-cp311-linux_x86_64.whl
+    pip install https://github.com/flashinfer-ai/flashinfer/releases/download/v0.0.9/flashinfer-0.0.9+cu121torch2.3-cp311-cp311-linux_x86_64.whl
 
 ENV HF_HUB_OFFLINE=1 \
     PORT=8000 \


### PR DESCRIPTION
https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.0.9
