### PR TITLE
[CI/Build] fix: update setup.py to differentiate between fork and upstream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -457,18 +457,17 @@ if envs.VLLM_USE_PRECOMPILED:
     package_data["vllm"].append("*.so")
 
 setup(
-    name="vllm",
+    name="vllm-odh",
     version=get_vllm_version(),
-    author="vLLM Team",
+    author="Open Data Hub Community",
     license="Apache 2.0",
     description=("A high-throughput and memory-efficient inference and "
                  "serving engine for LLMs"),
     long_description=read_readme(),
     long_description_content_type="text/markdown",
-    url="https://github.com/vllm-project/vllm",
+    url="https://github.com/opendatahub-io/vllm",
     project_urls={
-        "Homepage": "https://github.com/vllm-project/vllm",
-        "Documentation": "https://vllm.readthedocs.io/en/latest/",
+        "Homepage": "https://github.com/opendatahub-io/vllm",
     },
     classifiers=[
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
This PR updates `setup.py` to differentiate between the ODH and upstream vLLM projects. This work would be a prereq to making this into an independent PyPI package.

