### PR TITLE
deps: bump vllm-tgis-adapter to 0.2.3

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -193,7 +193,7 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.2.2
+    pip install vllm-tgis-adapter==0.2.3
 
 ENV GRPC_PORT=8033
 USER 2000


### PR DESCRIPTION
Required for vLLM 0.5.3.post1 support. See https://github.com/opendatahub-io/vllm-tgis-adapter/releases/tag/0.2.3