### PR TITLE
Dockerfile.ubi: add missing dependency

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -71,6 +71,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements-cuda.txt,target=requirements-cuda.txt \
     --mount=type=bind,source=requirements-dev.txt,target=requirements-dev.txt \
     --mount=type=bind,source=requirements-lint.txt,target=requirements-lint.txt \
+    --mount=type=bind,source=requirements-adag.txt,target=requirements-adag.txt \
     --mount=type=bind,source=requirements-test.txt,target=requirements-test.txt \
     pip3 install \
         -r requirements-cuda.txt \


### PR DESCRIPTION
`requirements-adag.txt` (required for ray accelerated dag) is required as part of of `requirements-dev.txt` -> `requirements-test.txt`