### PR TITLE
Allow long max seq length by default

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -183,6 +183,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ENV HF_HUB_OFFLINE=1 \
     PORT=8000 \
     HOME=/home/vllm \
+    # Allow requested max length to exceed what is extracted from the
+    # config.json
+    # see: https://github.com/vllm-project/vllm/pull/7080
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork
 


### PR DESCRIPTION
Set `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` in the UBI docker build to have it enabled by default. This allows the operator to specify a `--max-model-len` that exceeds the value parsed from the model's `config.json`. A warning will still be printed, but the server will not crash.

See: https://github.com/vllm-project/vllm/pull/7080