### PR TITLE
Add script to wait for the model to appear when using KServe Modelcar

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -196,9 +196,11 @@ RUN umask 002 \
     && chmod g+rwx $HOME /usr/src /workspace
 
 COPY LICENSE /licenses/vllm.md
+COPY --chown=2000:0 --chmod=554 extras/wait-modelcar.sh .
 
 USER 2000
-ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+ENTRYPOINT ["/workspace/wait-modelcar.sh"]
+CMD ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 
 
 FROM vllm-openai as vllm-grpc-adapter
@@ -217,4 +219,4 @@ ENV GRPC_PORT=8033 \
     DISABLE_LOGPROBS_DURING_SPEC_DECODING=false
 
 USER 2000
-ENTRYPOINT ["python3", "-m", "vllm_tgis_adapter", "--uvicorn-log-level=warning"]
+CMD ["python3", "-m", "vllm_tgis_adapter", "--uvicorn-log-level=warning"]

--- a/extras/wait-modelcar.sh
+++ b/extras/wait-modelcar.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${MODEL_INIT_MODE}" = "async" ] ; then
+  echo "Waiting for model files (modelcar) to be present..."
+  until test -e /mnt/models; do
+    sleep 1
+  done
+
+  echo "Model files are now available."
+fi
+
+echo "Starting model server..."
+eval $@
+


### PR DESCRIPTION
When using OCI containers for model storage in KServe (modelcar), there is the possibility that the model server starts before the model has been fully downloaded. When this happens, the model server would terminate with error because the model path is empty.

This adds a small script to wait for the cluster to fully download the model container before invoking the model server. The waiting is triggered when the MODEL_INIT_MODE environment variable is set to the "async".

