### PR TITLE
Dockerfile.hpu: downgrade vllm-tgis-adapter to a compatible version

### DIFF
--- a/Dockerfile.hpu.ubi
+++ b/Dockerfile.hpu.ubi
@@ -104,7 +104,8 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.2.3
+    --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
+    pip install $(echo dist/*.whl)'[tensorizer]' vllm-tgis-adapter==0.2.3
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \

--- a/Dockerfile.hpu.ubi
+++ b/Dockerfile.hpu.ubi
@@ -104,7 +104,7 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.5.3
+    pip install vllm-tgis-adapter==0.2.3
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \


### PR DESCRIPTION
Gaudi 1.18 release is based on `vllm==0.5.3.post1`. `vllm-tgis-adapter==0.5.3` on the other hand, requires `vllm>=0.6.2`, causing pip to install the latest upstream version:

```
...
2024-10-15T09:34:03.988623557Z   Attempting uninstall: vllm
2024-10-15T09:34:03.992329502Z     Found existing installation: vllm 0.5.3.post1+gaudi000
2024-10-15T09:34:04.033438958Z     Uninstalling vllm-0.5.3.post1+gaudi000:
2024-10-15T09:34:04.038142099Z       Successfully uninstalled vllm-0.5.3.post1+gaudi000
...
```

The solution is to downgrade `vllm-tgis-adapter` with the latest version compatible with `vllm==0.5.3.post1`, which is `vllm-tgis-adapter==0.2.3`
