### PR TITLE
Dockerfile*.ubi: install vllm and vllm-tgis-adapter in the same step to make sure the correct version is installed

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -240,7 +240,8 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.5.3
+    --mount=type=bind,from=build_vllm,src=/workspace/dist,target=/install/vllm/ \
+    uv pip install /install/vllm/*.whl vllm-tgis-adapter==0.5.3
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -202,7 +202,8 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install vllm-tgis-adapter==0.5.3
+    --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
+    uv pip install $(echo dist/*.whl)'[tensorizer]' vllm-tgis-adapter==0.5.3
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \


### PR DESCRIPTION
When git tags aren't present, `setuptools-scm` sets version to `0.1.dev`, causing the vllm-tgis-adapter layer to find an incompatible vllm version and re-install a compatible one:

```
[build]   Attempting uninstall:vllm
[build]     Found existing installation: vllm 0.1.dev1+g7f00e6e.cu124
[build]     Uninstalling vllm-0.1.dev1+g7f00e6e.cu124:
[build]       Successfully uninstalled vllm-0.1.dev1+g7f00e6e.cu124
```

By forcing installation of the correct vllm version along with the adapter, we will cause errors when this happens:

```
#33 ERROR: process "/bin/sh -c uv pip install $(echo dist/*.whl)'[tensorizer]' vllm-tgis-adapter==0.5.3" did not complete successfully: exit code: 1
------
 > [vllm-grpc-adapter 1/1] RUN --mount=type=cache,target=/root/.cache/pip     --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist     uv pip install $(echo dist/*.whl)'[tensorizer]' vllm-tgis-adapter==0.5.
3:
0.365 Using Python 3.12.1 environment at /opt/vllm
0.858   × No solution found when resolving dependencies:
0.858   ╰─▶ Because only vllm[tensorizer]==0.1.dev3065+g5122293.d20241016.empty
0.858       is available and vllm-tgis-adapter==0.5.3 depends on vllm>=0.6.2,
0.858       we can conclude that vllm-tgis-adapter==0.5.3 and all versions of
0.858       vllm[tensorizer] are incompatible.
0.858       And because you require vllm-tgis-adapter==0.5.3 and vllm[tensorizer],
0.858       we can conclude that your requirements are unsatisfiable.
```

fixes https://issues.redhat.com/browse/RHOAIENG-14534