### PR TITLE
Dockerfile.ubi: add env vars to prevent nbumba/outlines errors

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -182,6 +182,9 @@ ENV HF_HUB_OFFLINE=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork \
+    OUTLINES_CACHE_DIR=/tmp/outlines \
+    NUMBA_CACHE_DIR=/tmp/numba \
+    TRITON_CACHE_DIR=/tmp/triton \
     VLLM_NO_USAGE_STATS=1
 
 # setup non-root user for OpenShift


### PR DESCRIPTION
When using guided decoding, `numba` attempts to use `NUMBA_CACHE_DIR` and `outlines` attempts to use `OUTLINES_CACHE_DIR`, which must be set to a writable location:

This fixes the following crashes:

```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/__main__.py", line 18, in <module>
    from .grpc import run_grpc_server
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/grpc/__init__.py", line 1, in <module>
    from .grpc_server import run_grpc_server
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/grpc/grpc_server.py", line 30, in <module>
    from vllm_tgis_adapter.tgis_utils.guided_decoding import (
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/tgis_utils/guided_decoding.py", line 7, in <module>
    from vllm.model_executor.guided_decoding import outlines_decoding
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/model_executor/guided_decoding/outlines_decoding.py", line 10, in <module>
    from vllm.model_executor.guided_decoding.outlines_logits_processors import (
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/model_executor/guided_decoding/outlines_logits_processors.py", line 25, in <module>
    from outlines import grammars
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/__init__.py", line 2, in <module>
    import outlines.generate
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/generate/__init__.py", line 2, in <module>
    from .cfg import cfg
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/generate/cfg.py", line 3, in <module>
    from outlines.fsm.guide import CFGGuide
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/fsm/guide.py", line 9, in <module>
    from outlines.fsm.regex import (
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/fsm/regex.py", line 113, in <module>
    @numba.njit(cache=True)
     ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/numba/core/decorators.py", line 225, in wrapper
    disp.enable_caching()
  File "/opt/vllm/lib64/python3.12/site-packages/numba/core/dispatcher.py", line 808, in enable_caching
    self._cache = FunctionCache(self.py_func)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/numba/core/caching.py", line 601, in __init__
    self._impl = self._impl_class(py_func)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/numba/core/caching.py", line 337, in __init__
    raise RuntimeError("cannot cache function %r: no locator available "
RuntimeError: cannot cache function 'create_fsm_info': no locator available for file '/opt/vllm/lib64/python3.12/site-packages/outlines/fsm/regex.py'
```


```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/__main__.py", line 18, in <module>
    from .grpc import run_grpc_server
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/grpc/__init__.py", line 1, in <module>
    from .grpc_server import run_grpc_server
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/grpc/grpc_server.py", line 30, in <module>
    from vllm_tgis_adapter.tgis_utils.guided_decoding import (
  File "/opt/vllm/lib64/python3.12/site-packages/vllm_tgis_adapter/tgis_utils/guided_decoding.py", line 7, in <module>
    from vllm.model_executor.guided_decoding import outlines_decoding
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/model_executor/guided_decoding/outlines_decoding.py", line 10, in <module>
    from vllm.model_executor.guided_decoding.outlines_logits_processors import (
  File "/opt/vllm/lib64/python3.12/site-packages/vllm/model_executor/guided_decoding/outlines_logits_processors.py", line 25, in <module>
    from outlines import grammars
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/__init__.py", line 2, in <module>
    import outlines.generate
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/generate/__init__.py", line 2, in <module>
    from .cfg import cfg
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/generate/cfg.py", line 3, in <module>
    from outlines.fsm.guide import CFGGuide
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/fsm/guide.py", line 108, in <module>
    @cache()
     ^^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/caching.py", line 93, in decorator
    memory = get_cache()
             ^^^^^^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/outlines/caching.py", line 55, in get_cache
    memory = Cache(
             ^^^^^^
  File "/opt/vllm/lib64/python3.12/site-packages/diskcache/core.py", line 450, in __init__
    raise EnvironmentError(
PermissionError: [Errno 13] Cache directory "/home/vllm/.cache/outlines" does not exist and could not be created
```
