### PR TITLE
Dockerfile.rocm.ubi: add --mount=type=cache to final pip install

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -240,6 +240,7 @@ FROM vllm-openai as vllm-grpc-adapter
 USER root
 
 RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=build_vllm,src=/workspace/dist,target=/install/vllm/ \
     uv pip install /install/vllm/*.whl vllm-tgis-adapter==0.5.3
 


### PR DESCRIPTION
Not having `--mount=type=cache,target=/root/.cache/vllm` results in the `uv` cache being included in the final image.