### PR TITLE
Dockerfile.rocm.ubi: reduce image size

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -48,6 +48,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         --index-url "https://download.pytorch.org/whl/nightly/rocm${version}" \
         torch==2.6.0.dev20241107+rocm${version}\
         torchvision==0.20.0.dev20241107+rocm${version} && \
+    # Install libdrm-amdgpu to avoid errors when retrieving device information (amdgpu.ids: No such file or directory)
+    microdnf install -y libdrm-amdgpu && \
     microdnf clean all
 
 

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 FROM base AS rocm_base
 ARG ROCM_VERSION=6.2.4
+ARG PYTHON_VERSION
 
 RUN printf "[amdgpu]\n\
 name=amdgpu\n\
@@ -53,10 +54,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     microdnf clean all
 
 
-ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.12/site-packages/numpy.libs:$LD_LIBRARY_PATH"
-ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.12/site-packages/pillow.libs:$LD_LIBRARY_PATH"
-ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.12/site-packages/triton/backends/amd/lib:$LD_LIBRARY_PATH"
-ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.12/site-packages/torch/lib:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/numpy.libs:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/pillow.libs:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/triton/backends/amd/lib:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/torch/lib:$LD_LIBRARY_PATH"
 
 FROM rocm_base as rocm_devel
 
@@ -95,7 +96,7 @@ WORKDIR /workspace
 
 ENV LLVM_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer
 ENV PATH=$PATH:/opt/rocm/bin
-ENV CPLUS_INCLUDE_PATH=$VIRTUAL_ENV/lib/python3.12/site-packages/torch/include:/opt/rocm/include
+ENV CPLUS_INCLUDE_PATH=$VIRTUAL_ENV/lib/python${PYTHON_VERSION}/site-packages/torch/include:/opt/rocm/include
 
 
 FROM rocm_devel AS build_amdsmi
@@ -135,6 +136,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM rocm_devel AS build_vllm
 ARG PYTORCH_ROCM_ARCH
+ARG PYTHON_VERSION
 ARG MAX_JOBS
 ENV MAX_JOBS=${MAX_JOBS}
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
@@ -149,7 +151,7 @@ ENV VLLM_INSTALL_PUNICA_KERNELS=1
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
-    ln -s /opt/vllm/lib64/python3.12/site-packages/torch/lib/libroctx64.so /opt/rocm/lib/libroctx64.so && \
+    ln -s /opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib/libroctx64.so /opt/rocm/lib/libroctx64.so && \
     uv pip install -v -U \
         ninja setuptools-scm>=8 "cmake>=3.26" packaging && \
     env CFLAGS="-march=haswell" \

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -41,11 +41,6 @@ gpgcheck=1\n\
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/amdgpu.repo
 
 
-RUN microdnf -y install \
-        rocm-hip-libraries rocm-hip-runtime \
-        miopen-hip && \
-    microdnf clean all
-
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
     export version="$(awk -F. '{print $1"."$2}' <<< $ROCM_VERSION)" && \
@@ -205,7 +200,7 @@ RUN --mount=type=bind,from=build_amdsmi,src=/install,target=/install/amdsmi/ \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
     export version="$(awk -F. '{print $1"."$2}' <<< $ROCM_VERSION)" && \
-    uv pip install -v  \
+    uv pip install \
         --index-strategy=unsafe-best-match \
         --extra-index-url "https://download.pytorch.org/whl/nightly/rocm${version}" \
         /install/amdsmi/*.whl\
@@ -216,9 +211,7 @@ RUN --mount=type=bind,from=build_amdsmi,src=/install,target=/install/amdsmi/ \
 RUN umask 002 && \
     useradd --uid 2000 --gid 0 vllm && \
     mkdir -p /licenses && \
-    chmod g+rwx $HOME /usr/src /workspace && \
-    chmod 0775 /var/log/rocm_smi_lib && \
-    chmod 0664 /var/log/rocm_smi_lib/*
+    chmod g+rwx $HOME /usr/src /workspace
 
 COPY LICENSE /licenses/vllm.md
 COPY examples/*.jinja /app/data/template/

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -70,22 +70,23 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
         git \
         # packages required to build vllm
         amd-smi \
-        rocm-device-libs \
-        rocrand-devel \
-        hiprand-devel \
-        rocblas-devel \
         hipblas-devel \
         hipblaslt-devel \
-        miopen-hip-devel \
-        hipfft-devel \
-        hipsparse-devel \
-        rocprim-devel \
-        hipcub-devel \
-        rocthrust-devel \
-        hipsolver-devel \
-        rccl-devel \
-        # end packages required to build vllm
         hipcc \
+        hipcub-devel \
+        hipfft-devel \
+        hiprand-devel \
+        hipsolver-devel \
+        hipsparse-devel \
+        hsa-rocr-devel \
+        miopen-hip-devel \
+        rccl-devel \
+        rocblas-devel \
+        rocm-device-libs \
+        rocprim-devel \
+        rocrand-devel \
+        rocthrust-devel \
+        # end packages required to build vllm
         wget \
         which && \
     microdnf clean all


### PR DESCRIPTION
The system libraries in `/opt/rocm` are actually already installed as part of the pytorch ROCm install.

By getting rid of the system libraries, we shave off ~18GB off the final image, ending up with a 20GB image (vs 36GB). All of this is basically duplicated ROCm libraries.
