### PR TITLE
Dockerfile.rocm.ubi: downgrade ROCm to 6.1.3, bump pytorch nightly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx11
 # versions are derived from Dockerfile.rocm
 #
 set(TORCH_SUPPORTED_VERSION_CUDA "2.4.0")
-set(TORCH_SUPPORTED_VERSION_ROCM "2.6.0")
+set(TORCH_SUPPORTED_VERSION_ROCM "2.5.0")
 
 #
 # Try to find python package with an executable that exactly matches

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 
 FROM base AS rocm_base
-ARG ROCM_VERSION=6.2.4
+ARG ROCM_VERSION=6.1.3
 ARG PYTHON_VERSION
 ARG BASE_UBI_IMAGE_TAG
 
@@ -49,8 +49,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     export version="$(awk -F. '{print $1"."$2}' <<< $ROCM_VERSION)" && \
     uv pip install --pre \
         --index-url "https://download.pytorch.org/whl/nightly/rocm${version}" \
-        torch==2.6.0.dev20241107+rocm${version}\
-        torchvision==0.20.0.dev20241107+rocm${version} && \
+        torch==2.6.0.dev20241113+rocm${version} \
+        torchvision==0.20.0.dev20241113+rocm${version} && \
     # Install libdrm-amdgpu to avoid errors when retrieving device information (amdgpu.ids: No such file or directory)
     microdnf install -y libdrm-amdgpu && \
     microdnf clean all


### PR DESCRIPTION
ROCm 6.2 ([release notes](https://github.com/ROCm/rocm/releases/tag/rocm-6.2.0)) bumps RCCL to `2.20.5` (from `2.18.6`), which introduces a regression: deployments with tensor-parallel>1 fail with `RuntimeError: std::bad_alloc`.

RCCL release notes: https://github.com/ROCm/rccl/releases/tag/rocm-6.2.0
