### PR TITLE
Dockerfile.rocm.ubi: bump ROCm to 6.3.4

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 
 FROM base AS rocm_base
-ARG ROCM_VERSION=6.3.1
+ARG ROCM_VERSION=6.3.4
 ARG PYTHON_VERSION
 ARG BASE_UBI_IMAGE_TAG
 

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -49,8 +49,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     export version="$(awk -F. '{print $1"."$2}' <<< $ROCM_VERSION)" && \
     uv pip install --pre \
         --index-url "https://download.pytorch.org/whl/nightly/rocm${version}" \
-        torch==2.6.0.dev20250104+rocm${version}\
-        torchvision==0.22.0.dev20250104+rocm${version} && \
+        torch==2.7.0.dev20250308+rocm${version}\
+        torchvision==0.22.0.dev20250308+rocm${version} && \
     # Install libdrm-amdgpu to avoid errors when retrieving device information (amdgpu.ids: No such file or directory)
     microdnf install -y libdrm-amdgpu && \
     microdnf clean all


### PR DESCRIPTION
- bump ROCm to 6.3.4
- bumps`torch` to a more recent nightly, fixing FIPS issues (https://github.com/pytorch/pytorch/issues/147236)

fixes https://issues.redhat.com/browse/RHOAIENG-21197 