### PR TITLE
fix: add gcc-gfortran package to dependency list

### DIFF
--- a/Dockerfile.s390x.ubi
+++ b/Dockerfile.s390x.ubi
@@ -16,7 +16,7 @@ ENV LANG=C.UTF-8 \
 RUN microdnf install -y \
     which procps findutils tar vim git gcc g++ make patch zlib-devel \
     libjpeg-turbo-devel libtiff-devel libpng-devel libwebp-devel freetype-devel harfbuzz-devel \
-    openssl-devel openblas openblas-devel autoconf automake libtool cmake && \
+    openssl-devel openblas openblas-devel autoconf automake libtool cmake gcc-gfortran   && \
     microdnf clean all
 
 # Python Installation

--- a/Dockerfile.s390x.ubi
+++ b/Dockerfile.s390x.ubi
@@ -16,7 +16,7 @@ ENV LANG=C.UTF-8 \
 RUN microdnf install -y \
     which procps findutils tar vim git gcc g++ make patch zlib-devel \
     libjpeg-turbo-devel libtiff-devel libpng-devel libwebp-devel freetype-devel harfbuzz-devel \
-    openssl-devel openblas openblas-devel autoconf automake libtool cmake gcc-gfortran   && \
+    openssl-devel openblas openblas-devel autoconf automake libtool cmake gcc-gfortran && \
     microdnf clean all
 
 # Python Installation


### PR DESCRIPTION
Hi, this PR addresses the following issues for s390x.

1. `gcc-gfortran` package is need for installing scipy which is recently introduced in `requirements-common.txt` file.
2. Renaming `Dockerfile.s390x` to `Dockerfile.s390x.ubi` to adhere to the naming convention for ubi Docker files.