### PR TITLE
Dockerfile.s390x: fix dependency build in vllm-tgis-adapter install

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -12,7 +12,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib
 # install gcc-13, python, rust, openblas
 # Note: A symlink for libatomic.so is created for gcc-13 (linker fails to find to find libatomic otherwise - reqd. for sentencepiece)
-# Note: A dummy file 'control' is created in /tmp/ to artifically create dependencies between stages when building stages in parallel
+# Note: A dummy file 'control' is created in /tmp/ to artificially create dependencies between stages when building stages in parallel
 #       when `--jobs=<N>` is passed with podman build command
 RUN microdnf install -y dnf \
     && dnf install -y https://mirror.stream.centos.org/9-stream/BaseOS/`arch`/os/Packages/centos-gpg-keys-9.0-24.el9.noarch.rpm \
@@ -40,7 +40,7 @@ RUN microdnf install -y dnf \
 # Stage to build torch family
 ###############################################################
 FROM base-builder AS torch-builder
-# buld cache without torch dependent packages
+# build cache without torch dependent packages
 # sentencepiece has linker issues otherwise
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,src=requirements-common.txt,dst=/requirements-common.txt,ro \

--- a/Dockerfile.s390x.ubi
+++ b/Dockerfile.s390x.ubi
@@ -104,9 +104,6 @@ ARG PYTHON_VERSION
 ENV LD_LIBRARY_PATH="/opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/lib:$LD_LIBRARY_PATH"
 ENV C_INCLUDE_PATH="/usr/local/include:$C_INCLUDE_PATH"
 ENV UV_LINK_MODE=copy
-ENV CARGO_HOME=/root/.cargo
-ENV RUSTUP_HOME=/root/.rustup
-ENV PATH="$CARGO_HOME/bin:$RUSTUP_HOME/bin:$PATH"
 
 COPY . /workspace/vllm
 WORKDIR /workspace/vllm
@@ -120,6 +117,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=rust,source=/root/.rustup,target=/root/.rustup,rw \
     --mount=type=bind,from=pyarrow,source=/tmp/arrow/python/dist,target=/tmp/arrow-wheels \
     --mount=type=bind,from=torch-vision,source=/tmp/vision/dist,target=/tmp/vision-wheels/ \
+    CARGO_HOME=/root/.cargo \
+    RUSTUP_HOME=/root/.rustup \
+    PATH="/root/.cargo/bin:/root/.rustup/bin:$PATH" \
      sed -i '/^torch/d' requirements-build.txt && \
      sed -i '/^numba/d' requirements-common.txt && \
      ARROW_WHL_FILE=$(ls /tmp/arrow-wheels/pyarrow-*.whl | head -n 1) && \
@@ -170,13 +170,12 @@ USER root
 
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 
-ENV CARGO_HOME=/root/.cargo
-ENV RUSTUP_HOME=/root/.rustup
-ENV PATH="$CARGO_HOME/bin:$RUSTUP_HOME/bin:$PATH"
-
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=rust,source=/root/.cargo,target=/root/.cargo,rw \
     --mount=type=bind,from=rust,source=/root/.rustup,target=/root/.rustup,rw \
+    CARGO_HOME=/root/.cargo \
+    RUSTUP_HOME=/root/.rustup \
+    PATH="/root/.cargo/bin:/root/.rustup/bin:$PATH" \
     HOME=/root uv pip install "$(echo /workspace/vllm/dist/*.whl)[tensorizer]" vllm-tgis-adapter==0.6.3
 
 ENV GRPC_PORT=8033 \

--- a/Dockerfile.s390x.ubi
+++ b/Dockerfile.s390x.ubi
@@ -170,7 +170,13 @@ USER root
 
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 
+ENV CARGO_HOME=/root/.cargo
+ENV RUSTUP_HOME=/root/.rustup
+ENV PATH="$CARGO_HOME/bin:$RUSTUP_HOME/bin:$PATH"
+
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,from=rust,source=/root/.cargo,target=/root/.cargo,rw \
+    --mount=type=bind,from=rust,source=/root/.rustup,target=/root/.rustup,rw \
     HOME=/root uv pip install "$(echo /workspace/vllm/dist/*.whl)[tensorizer]" vllm-tgis-adapter==0.6.3
 
 ENV GRPC_PORT=8033 \


### PR DESCRIPTION
This PR fixes docker failure for s390x.ubi that is caused by rust compiler in vllm-tgis adapter.

error:
```
[8/8] STEP 4/8: RUN --mount=type=cache,target=/root/.cache/uv     HOME=/root uv pip install "$(echo /workspace/vllm/dist/*.whl)[tensorizer]" vllm-tgis-adapter==0.6.3
Using Python 3.12.5 environment at: /opt/vllm
Resolved 136 packages in 227ms
   Building hf-transfer==0.1.9
   Building grpcio==1.70.0
  × Failed to build `hf-transfer==0.1.9`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)

      [stdout]
      Running `maturin pep517 build-wheel -i
      /root/.cache/uv/builds-v0/.tmpkYNZ1P/bin/python --compatibility off`

      [stderr]
      💥 maturin failed
        Caused by: Cargo metadata failed. Do you have cargo in your PATH?
        Caused by: No such file or directory (os error 2)
      Error: command ['maturin', 'pep517', 'build-wheel', '-i',
      '/root/.cache/uv/builds-v0/.tmpkYNZ1P/bin/python', '--compatibility',
      'off'] returned non-zero exit status 1

      hint: This usually indicates a problem with the package or the build
      environment.
  help: `hf-transfer` (v0.1.9) was included because `vllm-tgis-adapter`
        (v0.6.3) depends on `hf-transfer`
```