### PR TITLE
Dockerfile.ppc64le.ubi: retry openblas install on failure, pin cmake<4

### DIFF
--- a/Dockerfile.ppc64le.ubi
+++ b/Dockerfile.ppc64le.ubi
@@ -37,8 +37,8 @@ RUN microdnf install -y dnf openssl-devel \
     && ln -sf /usr/lib64/libatomic.so.1 /usr/lib64/libatomic.so \
     && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
     && python -m pip install -U pip uv \
-    && uv pip install wheel build setuptools setuptools_scm setuptools_rust meson-python cmake ninja cython scikit_build_core scikit_build \
-    && curl -sL https://ftp2.osuosl.org/pub/ppc64el/openblas/latest/Openblas_${OPENBLAS_VERSION}_ppc64le.tar.gz | tar xvf - -C /usr/local \
+    && uv pip install wheel build setuptools setuptools_scm setuptools_rust meson-python 'cmake<4' ninja cython scikit_build_core scikit_build \
+    && curl -L --no-progress-meter --retry 5 --retry-connrefused https://ftp2.osuosl.org/pub/ppc64el/openblas/latest/Openblas_${OPENBLAS_VERSION}_ppc64le.tar.gz | tar xvf - -C /usr/local \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && cd /tmp && touch control
 
@@ -263,9 +263,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     && microdnf clean all \
     && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
     && python -m pip install -U pip uv --no-cache \
-    && curl -sL https://ftp2.osuosl.org/pub/ppc64el/openblas/latest/Openblas_${OPENBLAS_VERSION}_ppc64le.tar.gz | tar xvf - -C /usr/local \
+    && curl -L --no-progress-meter --retry 5 --retry-connrefused https://ftp2.osuosl.org/pub/ppc64el/openblas/latest/Openblas_${OPENBLAS_VERSION}_ppc64le.tar.gz | tar xvf - -C /usr/local \
     && make -C /numactl install \
-    && uv pip install cmake \
+    && uv pip install 'cmake<4' \
     && cmake --install /lapack/build \
     && uv pip uninstall cmake
 


### PR DESCRIPTION
Downstream builds could intermittently fail because of poor connectivity of ppc konflux to the outside world, this PR retries on failures to avoid these intermittent build failures.

Pinning cmake<4 is required as cmake>=4 breaks the build. 